### PR TITLE
Gate CLI dependencies (clap, inferno, console, etc.) behind optional `cli` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [features]
+default = ["cli"]
+cli = ["dep:clap", "dep:clap_complete", "dep:console", "dep:ctrlc", "dep:indicatif", "dep:inferno", "dep:env_logger"]
 unwind = ["remoteprocess/unwind"]
 
 [package]
@@ -14,16 +16,21 @@ license = "MIT"
 build="build.rs"
 edition="2021"
 
+[[bin]]
+name = "py-spy"
+path = "src/main.rs"
+required-features = ["cli"]
+
 [dependencies]
 anyhow = "1"
-clap = {version="3.2", features=["wrap_help", "cargo", "derive"]}
-clap_complete="3.2"
-console = "0.16"
-ctrlc = "3"
-indicatif = "0.18"
-env_logger = "0.11"
+clap = {version="3.2", features=["wrap_help", "cargo", "derive"], optional = true}
+clap_complete = {version="3.2", optional = true}
+console = {version="0.16", optional = true}
+ctrlc = {version="3", optional = true}
+indicatif = {version="0.18", optional = true}
+env_logger = {version="0.11", optional = true}
 goblin = "0.10.0"
-inferno = "0.12.3"
+inferno = {version="0.12.3", optional = true}
 lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "cli")]
 use clap::{
     crate_description, crate_name, crate_version, value_parser, Arg, ArgEnum, Command,
     PossibleValue,
@@ -62,7 +63,8 @@ pub struct Config {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(ArgEnum, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "cli", derive(ArgEnum))]
 pub enum FileFormat {
     flamegraph,
     raw,
@@ -70,6 +72,7 @@ pub enum FileFormat {
     chrometrace,
 }
 
+#[cfg(feature = "cli")]
 impl FileFormat {
     pub fn possible_values() -> impl Iterator<Item = PossibleValue<'static>> {
         FileFormat::value_variants()
@@ -78,6 +81,7 @@ impl FileFormat {
     }
 }
 
+#[cfg(feature = "cli")]
 impl std::str::FromStr for FileFormat {
     type Err = String;
 
@@ -88,6 +92,21 @@ impl std::str::FromStr for FileFormat {
             }
         }
         Err(format!("Invalid fileformat: {s}"))
+    }
+}
+
+#[cfg(not(feature = "cli"))]
+impl std::str::FromStr for FileFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "flamegraph" => Ok(FileFormat::flamegraph),
+            "raw" => Ok(FileFormat::raw),
+            "speedscope" => Ok(FileFormat::speedscope),
+            "chrometrace" => Ok(FileFormat::chrometrace),
+            _ => Err(format!("Invalid fileformat: {s}")),
+        }
     }
 }
 
@@ -143,6 +162,7 @@ impl Default for Config {
     }
 }
 
+#[cfg(feature = "cli")]
 impl Config {
     /// Uses clap to set config options from commandline arguments
     pub fn from_commandline() -> Config {
@@ -491,6 +511,7 @@ impl Config {
     }
 }
 
+#[cfg(feature = "cli")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,11 @@ extern crate log;
 
 pub mod binary_parser;
 pub mod config;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "cli"))]
 pub mod coredump;
 #[cfg(feature = "unwind")]
 mod cython;
+#[cfg(feature = "cli")]
 pub mod dump;
 #[cfg(feature = "unwind")]
 mod native_stack_trace;


### PR DESCRIPTION
## Summary

py-spy is used as a library in pyroscope-rs, where CLI-only dependencies add unnecessary compile time and binary bloat. This PR introduces a `cli` feature flag (enabled by default) that gates all CLI-only dependencies, allowing library consumers to opt out with `default-features = false`.

### Dependencies gated behind `cli`

- `clap` + `clap_complete` (argument parsing)
- `inferno` (flamegraph SVG generation)
- `console` (terminal styling)
- `ctrlc` (signal handling)
- `indicatif` (progress bars)
- `env_logger` (logging initialization)

### Changes

- **`Cargo.toml`**: Added `default = ["cli"]` feature definition. Made 7 dependencies optional via `optional = true`. Added `[[bin]]` section with `required-features = ["cli"]` so `cargo build --no-default-features` skips the binary and only builds the library.
- **`src/config.rs`**: Gated clap imports, `ArgEnum` derive, `possible_values()`, `from_commandline()`, `from_args()`, and CLI tests behind `#[cfg(feature = "cli")]`. Added a standalone `FromStr` impl for `FileFormat` when `cli` is disabled.
- **`src/lib.rs`**: Gated `pub mod dump` and `pub mod coredump` behind `#[cfg(feature = "cli")]` since they depend on the `console` crate.

### Usage

```toml
# Full CLI (default, unchanged behavior):
py-spy = "0.4.1"

# Library only (no CLI deps):
py-spy = { version = "0.4.1", default-features = false }
```